### PR TITLE
Fix warnings for %lu in printf

### DIFF
--- a/adjust.h
+++ b/adjust.h
@@ -760,8 +760,8 @@ static void *_adjust_register_and_get(const _ADJUST_TYPE type, void *val,
 
     fprintf(stderr,
             "Error: unhandled control flow pattern _adjust_register_and_get "
-            "for args %s:%lu\n",
-            file_name, (long unsigned int)line_number);
+            "for args %s:%zu\n",
+            file_name, line_number);
     exit(1);
 }
 
@@ -870,8 +870,8 @@ static void adjust_update_index(const size_t index)
         {
             if (fgets(buffer, sizeof(buffer), file) == NULL)
             {
-                fprintf(stderr, "Error: EOF before line %lu in %s\n",
-                        (long unsigned int)e.line_number, af.file_name);
+                fprintf(stderr, "Error: EOF before line %zu in %s\n",
+                        e.line_number, af.file_name);
                 fclose(file);
                 exit(1);
             }
@@ -886,8 +886,8 @@ static void adjust_update_index(const size_t index)
             if (value_start == NULL)
             {
                 fprintf(stderr,
-                        "Error: no comma found in ADJUST macro: %s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                        "Error: no comma found in ADJUST macro: %s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
@@ -903,16 +903,16 @@ static void adjust_update_index(const size_t index)
             value_start = strchr(buffer, '(');
             if (value_start == NULL)
             {
-                fprintf(stderr, "Error: no opening paren found: %s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                fprintf(stderr, "Error: no opening paren found: %s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
         }
         else
         {
-            fprintf(stderr, "Error: unrecognized ADJUST macro format: %s:%lu\n",
-                    af.file_name, (long unsigned int)e.line_number);
+            fprintf(stderr, "Error: unrecognized ADJUST macro format: %s:%zu\n",
+                    af.file_name, e.line_number);
             fclose(file);
             exit(1);
         }
@@ -930,8 +930,8 @@ static void adjust_update_index(const size_t index)
         {
             if (sscanf(value_start, "%f", (float *)e.data) != 1)
             {
-                fprintf(stderr, "Error: failed to parse float: %s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                fprintf(stderr, "Error: failed to parse float: %s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
@@ -943,8 +943,8 @@ static void adjust_update_index(const size_t index)
         {
             if (sscanf(value_start, "%i", (int *)e.data) != 1)
             {
-                fprintf(stderr, "Error, failed to parse int: %s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                fprintf(stderr, "Error, failed to parse int: %s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
@@ -968,8 +968,8 @@ static void adjust_update_index(const size_t index)
             else
             {
                 fprintf(stderr,
-                        "Error: failed to parse bool (true or false): %s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                        "Error: failed to parse bool (true or false): %s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
@@ -986,8 +986,8 @@ static void adjust_update_index(const size_t index)
             {
                 fprintf(stderr,
                         "Error: failed to find starting quotation (\'): "
-                        "%s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                        "%s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
@@ -995,8 +995,8 @@ static void adjust_update_index(const size_t index)
             ++quote_start;
             if (*quote_start == '\'')
             {
-                fprintf(stderr, "Error: char format '' invalid in C, %s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                fprintf(stderr, "Error: char format '' invalid in C, %s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
@@ -1008,8 +1008,8 @@ static void adjust_update_index(const size_t index)
 
             if (*(quote_start + 1) != '\'')
             {
-                fprintf(stderr, "Error: missing ending ' for char, %s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                fprintf(stderr, "Error: missing ending ' for char, %s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
@@ -1029,8 +1029,8 @@ static void adjust_update_index(const size_t index)
             {
                 fprintf(stderr,
                         "Error: failed to find starting quotation (\"): "
-                        "%s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                        "%s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
@@ -1056,8 +1056,8 @@ static void adjust_update_index(const size_t index)
             if (*quote_end != '"')
             {
                 fprintf(stderr,
-                        "Error: failed to find ending quotation (\"): %s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                        "Error: failed to find ending quotation (\"): %s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }
@@ -1068,8 +1068,8 @@ static void adjust_update_index(const size_t index)
             if (!new_string)
             {
                 fprintf(stderr,
-                        "Error: failed to reallocate string memory: %s:%lu\n",
-                        af.file_name, (long unsigned int)e.line_number);
+                        "Error: failed to reallocate string memory: %s:%zu\n",
+                        af.file_name, e.line_number);
                 fclose(file);
                 exit(1);
             }


### PR DESCRIPTION
It can cause problems when compiling warnings as errors.
I just casted variables as `(long unsigned int)`, maybe you have better idea or code formatting in mind.

PS. would be great to get a workaround for unused functions.